### PR TITLE
#5 wrap database connection in Connection class

### DIFF
--- a/scripts/Connection.class.php
+++ b/scripts/Connection.class.php
@@ -8,20 +8,20 @@ class Connection {
 	protected static $conn;
 
 	public function __construct() {
-		if (!isset($this->conn)) {
+		if (!isset(self::$conn)) {
 			$config = require ($_SERVER['DOCUMENT_ROOT'] . '/../config.php');
 			// Create connection
-			$this->conn = new mysqli($config['servername'], $config['username'], $config['password'], $config['DBname']);
+			self::$conn = new mysqli($config['servername'], $config['username'], $config['password'], $config['DBname']);
 
 			// Check connection
-			if ($this->conn->connect_error) {
-				die('Connection failed: ' . $this->conn->connect_error);
+			if (self::$conn->connect_error) {
+				die('Connection failed: ' . self::$conn->connect_error);
 			}
 		}
 	}
 
 	public function getConection() {
-		return $this->conn;
+		return self::$conn;
 	}
 
 }

--- a/scripts/Connection.class.php
+++ b/scripts/Connection.class.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * this class connects to the database via the mysqli interface
+ */
+
+class Connection {
+
+	protected static $conn;
+
+	public function __construct() {
+		if (!isset($this->conn)) {
+			$config = require ($_SERVER['DOCUMENT_ROOT'] . '/../config.php');
+			// Create connection
+			$this->conn = new mysqli($config['servername'], $config['username'], $config['password'], $config['DBname']);
+
+			// Check connection
+			if ($this->conn->connect_error) {
+				die('Connection failed: ' . $this->conn->connect_error);
+			}
+		}
+	}
+
+	public function getConection() {
+		return $this->conn;
+	}
+
+}

--- a/scripts/connection.php
+++ b/scripts/connection.php
@@ -1,10 +1,10 @@
 <?php
-$config = require ($_SERVER['DOCUMENT_ROOT'] . "../config.php");
-// Create connection
-$conn = new mysqli ( $config ['servername'], $config ['username'], $config ['password'], $config ['DBname'] );
+/*
+ * this file is a wrapper for the Connection class defined in
+ * scripts/Connection.class.php
+ * usage [DEPRECATED]: $conn = require 'connection.php'
+ */
 
-// Check connection
-if ($conn->connect_error) {
-	die ( "Connection failed: " . $conn->connect_error );
-}
-return $conn;
+require_once 'Connection.class.php';
+$conn = new Connection();
+return $conn->getConection();


### PR DESCRIPTION
The database connection is now managed by the `Connection` class. The old `connection.php` interface still exists for backwards compatibility.

This does not fix issue #5